### PR TITLE
Use arriba docker

### DIFF
--- a/dxapp.json
+++ b/dxapp.json
@@ -10,7 +10,7 @@
       "label": "arriba_tar",
       "class": "file",
       "optional": false,
-      "help": "File ID of Arriba tar file in DNAnexus"
+      "help": "Arriba docker tar file"
     },
     {
       "name": "bam",

--- a/src/code.sh
+++ b/src/code.sh
@@ -26,7 +26,7 @@ sample_name=$(echo $bam_prefix | cut -d '.' -f 1)
 
 # Run arriba
 
-docker_cmd="arriba_v*/arriba -x /data/in/bam/$bam_name \
+docker_cmd="arriba_v*/arriba -x /data/in/bam/$bam_name -c /data/in/chimeric/$chimeric_name\
     -o /data/out/output_fusions_files/${sample_name}_fusions.tsv -O /data/out/output_discarded_fusions/${sample_name}_fusions.discarded.tsv \
     -g /data/genome_lib/${lib_dir}/ctat_genome_lib_build_dir/ref_annot.gtf -a /data/genome_lib/${lib_dir}/ctat_genome_lib_build_dir/ref_genome.fa  \
     -b /arriba_v*/database/blacklist_hg38_GRCh38_v*.tsv.gz \
@@ -34,7 +34,11 @@ docker_cmd="arriba_v*/arriba -x /data/in/bam/$bam_name \
     -t /arriba_v*/database/known_fusions_hg38_GRCh38_v*.tsv.gz \
     -p /arriba_v*/database/protein_domains_hg38_GRCh38_v*.gff3"
 
-time docker run -v /home/dnanexus:/data $DOCKER_IMAGE_ID  /bin/bash -c "eval $docker_cmd"
+time docker run --rm --security-opt=no-new-privileges \
+    --cap-drop=ALL \
+    --network=none \
+    -v /home/dnanexus:/data:ro \
+    $DOCKER_IMAGE_ID /bin/bash -c "eval $docker_cmd"
 
 for f in Log*; do
     mv "$f" "${sample_name}.$f";

--- a/src/code.sh
+++ b/src/code.sh
@@ -31,6 +31,7 @@ docker_cmd="arriba_v*/arriba -x /data/in/bam/$bam_name \
     -g /data/genome_lib/${lib_dir}/ctat_genome_lib_build_dir/ref_annot.gtf -a /data/genome_lib/${lib_dir}/ctat_genome_lib_build_dir/ref_genome.fa  \
     -b /arriba_v*/database/blacklist_hg38_GRCh38_v*.tsv.gz \
     -k /arriba_v*/database/known_fusions_hg38_GRCh38_v*.tsv.gz \
+    -t /arriba_v*/database/known_fusions_hg38_GRCh38_v*.tsv.gz \
     -p /arriba_v*/database/protein_domains_hg38_GRCh38_v*.gff3"
 
 time docker run -v /home/dnanexus:/data $DOCKER_IMAGE_ID  /bin/bash -c "eval $docker_cmd"

--- a/src/code.sh
+++ b/src/code.sh
@@ -26,9 +26,11 @@ sample_name=$(echo $bam_prefix | cut -d '.' -f 1)
 
 # Run arriba
 
-docker_cmd="arriba_v*/arriba -x /data/in/bam/$bam_name -c /data/in/chimeric/$chimeric_name\
-    -o /data/out/output_fusions_files/${sample_name}_fusions.tsv -O /data/out/output_discarded_fusions/${sample_name}_fusions.discarded.tsv \
-    -g /data/genome_lib/${lib_dir}/ctat_genome_lib_build_dir/ref_annot.gtf -a /data/genome_lib/${lib_dir}/ctat_genome_lib_build_dir/ref_genome.fa  \
+docker_cmd="arriba_v*/arriba -x /data/in/bam/$bam_name \
+    -o /data/out/output_fusions_files/${sample_name}_fusions.tsv \
+    -O /data/out/output_discarded_fusions/${sample_name}_fusions.discarded.tsv \
+    -g /data/genome_lib/${lib_dir}/ctat_genome_lib_build_dir/ref_annot.gtf \
+    -a /data/genome_lib/${lib_dir}/ctat_genome_lib_build_dir/ref_genome.fa  \
     -b /arriba_v*/database/blacklist_hg38_GRCh38_v*.tsv.gz \
     -k /arriba_v*/database/known_fusions_hg38_GRCh38_v*.tsv.gz \
     -t /arriba_v*/database/known_fusions_hg38_GRCh38_v*.tsv.gz \

--- a/src/code.sh
+++ b/src/code.sh
@@ -6,9 +6,8 @@ set -exo pipefail
 # Download all inputs from dx json
 dx-download-all-inputs
 
-mkdir -p /home/dnanexus/out/output_fusions_files \
-    /home/dnanexus/out/output_discarded_fusions \
-    /home/dnanexus/out/logs \
+mkdir -p /home/dnanexus/out/arriba_full \
+    /home/dnanexus/out/arriba_discarded \
     /home/dnanexus/genome_lib
 
 # Unpack CTAT bundle file
@@ -27,8 +26,8 @@ sample_name=$(echo $bam_prefix | cut -d '.' -f 1)
 # Run arriba
 
 docker_cmd="arriba_v*/arriba -x /data/in/bam/$bam_name \
-    -o /data/out/output_fusions_files/${sample_name}_fusions.tsv \
-    -O /data/out/output_discarded_fusions/${sample_name}_fusions.discarded.tsv \
+    -o /data/out/arriba_full/${sample_name}_fusions.tsv \
+    -O /data/out/arriba_discarded/${sample_name}_fusions.discarded.tsv \
     -g /data/genome_lib/${lib_dir}/ctat_genome_lib_build_dir/ref_annot.gtf \
     -a /data/genome_lib/${lib_dir}/ctat_genome_lib_build_dir/ref_genome.fa  \
     -b /arriba_v*/database/blacklist_hg38_GRCh38_v*.tsv.gz \
@@ -36,15 +35,9 @@ docker_cmd="arriba_v*/arriba -x /data/in/bam/$bam_name \
     -t /arriba_v*/database/known_fusions_hg38_GRCh38_v*.tsv.gz \
     -p /arriba_v*/database/protein_domains_hg38_GRCh38_v*.gff3"
 
-time docker run --rm --security-opt=no-new-privileges \
-    --cap-drop=ALL \
-    --network=none \
-    -v /home/dnanexus:/data:ro \
+time docker run --rm \
+    -v /home/dnanexus:/data \
     $DOCKER_IMAGE_ID /bin/bash -c "eval $docker_cmd"
 
-for f in Log*; do
-    mv "$f" "${sample_name}.$f";
-done
-mv /home/dnanexus/${sample_name}.Log* /home/dnanexus/out/logs
 
 dx-upload-all-outputs

--- a/src/code.sh
+++ b/src/code.sh
@@ -8,32 +8,32 @@ dx-download-all-inputs
 
 mkdir -p /home/dnanexus/out/output_fusions_files \
     /home/dnanexus/out/output_discarded_fusions \
-    /home/dnanexus/out/logs
+    /home/dnanexus/out/logs \
+    /home/dnanexus/genome_lib
 
-#unpack CTAT bundle file
+# Unpack CTAT bundle file
 tar xvzf /home/dnanexus/in/genome_lib/*.tar.gz -C /home/dnanexus/genome_lib
 
 # Extract CTAT library filename
 lib_dir=$(find /home/dnanexus/genome_lib -type d -name "*" -mindepth 1 -maxdepth 1 | rev | cut -d'/' -f-1 | rev)
 
-if ! tar -xzf /home/dnanexus/in/arriba_tar/*.tar.gz -C /home/dnanexus/ --one-top-level=arriba; then
-    echo "Error: Failed to extract arriba library"
-    exit 1
-fi
-
-cd arriba && make
-cd ..
-export PATH=$PATH:/home/dnanexus/arriba
+# Load arriba docker
+docker load -i $arriba_tar_path
+DOCKER_IMAGE_ID=$(docker images --format="{{.Repository}} {{.ID}}" | grep "^uhrigs/arriba" | cut -d' ' -f2)
 
 #Extract sample name from input_bam
-sample_name=$(echo $bam_prefix | cut -d '_' -f 1)
+sample_name=$(echo $bam_prefix | cut -d '.' -f 1)
 
 # Run arriba
-arriba \
-    -x $bam_path \
-    -o /home/dnanexus/out/output_fusions_files/${sample_name}_fusions.tsv -O /home/dnanexus/out/output_discarded_fusions/${sample_name}_fusions.discarded.tsv \
-    -a /home/dnanexus/genome_lib/${lib_dir}/ctat_genome_lib_build_dir/ref_genome.fa -g /home/dnanexus/genome_lib/${lib_dir}/ctat_genome_lib_build_dir/ref_annot.gtf \
-    -b /home/dnanexus/arriba/database/blacklist_hg38_GRCh38_v*.tsv.gz -k /home/dnanexus/arriba/database/known_fusions_hg38_GRCh38_v*.tsv.gz -t /home/dnanexus/arriba/database/known_fusions_hg38_GRCh38_v*.tsv.gz -p /home/dnanexus/arriba/database/protein_domains_hg38_GRCh38_v*.gff3
+
+docker_cmd="arriba_v*/arriba -x /data/in/bam/$bam_name \
+    -o /data/out/output_fusions_files/${sample_name}_fusions.tsv -O /data/out/output_discarded_fusions/${sample_name}_fusions.discarded.tsv \
+    -g /data/genome_lib/${lib_dir}/ctat_genome_lib_build_dir/ref_annot.gtf -a /data/genome_lib/${lib_dir}/ctat_genome_lib_build_dir/ref_genome.fa  \
+    -b /arriba_v*/database/blacklist_hg38_GRCh38_v*.tsv.gz \
+    -k /arriba_v*/database/known_fusions_hg38_GRCh38_v*.tsv.gz \
+    -p /arriba_v*/database/protein_domains_hg38_GRCh38_v*.gff3"
+
+time docker run -v /home/dnanexus:/data $DOCKER_IMAGE_ID  /bin/bash -c "eval $docker_cmd"
 
 for f in Log*; do
     mv "$f" "${sample_name}.$f";


### PR DESCRIPTION
- Use docker rather than compiling arriba 
- Uses command from run_arriba.sh to avoid using STAR -> https://github.com/suhrig/arriba/blob/master/run_arriba.sh#L41

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_arriba/2)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Refined the configuration prompt for the Arriba input, now clearly indicating it uses a Docker tar file.

- **New Features**
  - Transitioned Arriba tool execution from a local extraction method to a containerised Docker-based approach.
  - Updated file path handling and sample name parsing, with added execution time tracking for improved performance monitoring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->