### PR TITLE
Annotate Exon

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ The app also produces visualisation plots of fusions predicted.
  - Arriba docker
  - CTAT genome resource
  - Visualisation (boolean true/false)
- - STAR-Fusion predictions
 
 ## What are the outputs?
  - Predicted fusions

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## What does this app do?
 
-This app detects gene fusions from STAR aligned BAM files. The BAM file used by arriba must contain split reads or discordant mates. This can be done by running STARaligner with parameter `--chimOutType WithinBAM`.
+This app detects gene fusions from STAR aligned BAM files and annotates them with exon numbers. The BAM file used by arriba must contain split reads or discordant mates. This can be done by running STARaligner with parameter `--chimOutType WithinBAM`.
 
 The app also produces visualisation plots of fusions predicted.
 
@@ -13,7 +13,7 @@ The app also produces visualisation plots of fusions predicted.
  - Visualisation (boolean true/false)
 
 ## What are the outputs?
- - Predicted fusions
+ - Predicted fusions (annotated with exon numbers)
  - Discarded fusions (fusions that Arriba classified as an artifact or that are also observed in healthy tissue. Useful to check in case a fusion that should have been predicted is not found in the predicted fusions file)
  - Visualisation plots (concatenated into a single pdf file)
 

--- a/dxapp.json
+++ b/dxapp.json
@@ -51,16 +51,6 @@
       "class": "boolean",
       "optional": true,
       "help": "Optional output, set to true to generate visualisations of the gene fusions."
-    },
-    {
-      "name": "starfusion",
-      "label": "starfusion",
-      "class": "file",
-      "optional": false,
-      "patterns": [
-        "*.tsv"
-      ],
-      "help": "STAR-Fusion predicted outputs"
     }
   ],
   "outputSpec": [

--- a/dxapp.json
+++ b/dxapp.json
@@ -23,7 +23,7 @@
       "patterns": [
         "*.bam"
       ],
-      "help": "RNA-Seq BAM file from starfusion containing chimeric junctions for fusion detection"
+      "help": "RNA-Seq BAM file from STAR containing chimeric junctions for fusion detection"
     },
     {
       "name": "index",
@@ -33,7 +33,7 @@
       "patterns": [
         "*.bai"
       ],
-      "help": "RNA-Seq BAM Index file from starfusion"
+      "help": "RNA-Seq BAM Index file from STAR"
     },
     {
       "name": "genome_lib",

--- a/src/code.sh
+++ b/src/code.sh
@@ -40,14 +40,14 @@ _set_env() {
         blacklist_file \
         known_fusions \
         sample_name \
-        star_fusion_bam
+        star_bam
 
     # Extract CTAT library filename
     lib_dir=$(find /home/dnanexus/genome_lib -type d -name "*" -mindepth 1 -maxdepth 1 | rev | cut -d'/' -f-1 | rev)
 
     # Extract sample name from input_bam
     sample_name=$(echo $bam_prefix | cut -d '.' -f 1)
-    star_fusion_bam="$bam_name"
+    star_bam="$bam_name"
 
     docker_image_id=$(docker images --format="{{.Repository}} {{.ID}}" | grep "^uhrigs/arriba" | cut -d' ' -f2)
 
@@ -172,7 +172,7 @@ _call_arriba_visualisation() {
 
     command="${arriba_version}/draw_fusions.R \
             --fusions=/data/${file} \
-            --alignments=/data/input/${star_fusion_bam} \
+            --alignments=/data/input/${star_bam} \
             --output=/data/split_pdfs/${output_suffix}_fusions.pdf \
             --annotation=/data/genome_lib/${lib_dir}/ctat_genome_lib_build_dir/ref_annot.gtf \
             --cytobands=/${arriba_version}/database/${cytobands_file} \

--- a/src/code.sh
+++ b/src/code.sh
@@ -105,7 +105,7 @@ _setup_arriba_visualisation() {
     : '''
     Setup for calling Arriba visualisation.
 
-    Splits out star fusion calls to equal length files for number of CPU cores available with
+    Splits out fusion calls to equal length files for number of CPU cores available with
     original header for calling visualisation script in parallel.
     '''
     mkdir -p /home/dnanexus/out/arriba_visualisations/ \
@@ -114,13 +114,13 @@ _setup_arriba_visualisation() {
             /home/dnanexus/visualisation_logs
 
     local header
-    header=$(head -n1 in/starfusion/${starfusion_name})
+    header=$(head -n1 out/arriba_full/${sample_name}_fusions.tsv)
 
-    sed -i '1d' in/starfusion/${starfusion_name}
-    split -n l/$(nproc --all) -e in/starfusion/${starfusion_name} split_fusions/
+    sed -i '1d' out/arriba_full/${sample_name}_fusions.tsv
+    split -n l/$(nproc --all) -e out/arriba_full/${sample_name}_fusions.tsv split_fusions/
     find split_fusions/ -type f -exec sed -i "1 i $header" {} \;
 
-    echo "$(wc -l < in/starfusion/${starfusion_name}) fusions to generate plots for, splitting across $(nproc --all) processes"
+    echo "$(wc -l < out/arriba_full/${sample_name}_fusions.tsv) fusions to generate plots for, splitting across $(nproc --all) processes"
 }
 
 _call_arriba_visualisation() {
@@ -163,7 +163,7 @@ main() {
 
     # Run the visualisation if requested by user
     if [[ "${arriba_visual_script,,}" == "true" ]]; then
-        if [[ $(wc -l < in/starfusion/${starfusion_name}) -ge 2 ]]; then
+        if [[ $(wc -l < out/arriba_full/${sample_name}_fusions.tsv) -ge 2 ]]; then
             _setup_arriba_visualisation
 
             # run Arriba to generate visualisations in parallel


### PR DESCRIPTION
- Remove starfusion visualisation
- Add exon annotation script
Example job: https://platform.dnanexus.com/panx/projects/J1XPj1j4vBJvG9Gz85VpZjJ4/monitor/job/J1z76Jj4vBJkB987ZzQ1yXq7

@nadia31415

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_arriba/10)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Fusion calls are now automatically annotated with exon numbers, enhancing output detail.

* **Documentation**
  * Updated the README to describe the new exon number annotation feature and clarified input requirements.

* **Chores**
  * Removed support for STAR-Fusion predicted outputs from the app’s input options.
  * Clarified input file descriptions to reference STAR instead of STAR-Fusion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->